### PR TITLE
remove the need for cp/mkdir/kill from haproxy image

### DIFF
--- a/images/haproxy/Dockerfile
+++ b/images/haproxy/Dockerfile
@@ -37,15 +37,9 @@ RUN echo deb http://deb.debian.org/debian buster-backports main \
 COPY --chmod=0755 stage-binary-and-deps.sh /usr/local/bin/
 
 # stage everything for copying into the final image
-# NOTE: kind currently also uses "mkdir" and "cp" to write files within the container
-# TODO: mkdir especially should be unnecessary, with a little refactoring
-# NOTE: kill is used to signal haproxy to reload
 ARG STAGE_DIR="/opt/stage"
 RUN mkdir -p "${STAGE_DIR}" && \
-    stage-binary-and-deps.sh haproxy "${STAGE_DIR}" && \
-    stage-binary-and-deps.sh cp "${STAGE_DIR}" && \
-    stage-binary-and-deps.sh mkdir "${STAGE_DIR}" && \
-    stage-binary-and-deps.sh kill "${STAGE_DIR}"
+    stage-binary-and-deps.sh haproxy "${STAGE_DIR}"
 
 ################################################################################
 

--- a/pkg/build/nodeimage/helpers.go
+++ b/pkg/build/nodeimage/helpers.go
@@ -34,7 +34,7 @@ func createFile(containerCmder exec.Cmder, filePath, contents string) error {
 	if err := containerCmder.Command("mkdir", "-p", path.Dir(filePath)).Run(); err != nil {
 		return err
 	}
-
+	// TODO: need to pass tar
 	return containerCmder.Command(
 		"cp", "/dev/stdin", filePath,
 	).SetStdin(

--- a/pkg/cluster/internal/create/actions/loadbalancer/loadbalancer.go
+++ b/pkg/cluster/internal/create/actions/loadbalancer/loadbalancer.go
@@ -91,7 +91,7 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 	}
 
 	// reload the config. haproxy will reload on SIGHUP
-	if err := loadBalancerNode.Command("kill", "-s", "HUP", "1").Run(); err != nil {
+	if err := loadBalancerNode.Command("kill", "-s", "HUP").Run(); err != nil {
 		return errors.Wrap(err, "failed to reload loadbalancer")
 	}
 

--- a/pkg/cluster/internal/loadbalancer/const.go
+++ b/pkg/cluster/internal/loadbalancer/const.go
@@ -17,7 +17,7 @@ limitations under the License.
 package loadbalancer
 
 // Image defines the loadbalancer image:tag
-const Image = "kindest/haproxy:v20210715-a6da3463"
+const Image = "kindest/haproxy:latest"
 
 // ConfigPath defines the path to the config file in the image
 const ConfigPath = "/usr/local/etc/haproxy/haproxy.cfg"

--- a/pkg/cluster/internal/providers/podman/node.go
+++ b/pkg/cluster/internal/providers/podman/node.go
@@ -100,6 +100,7 @@ type nodeCmd struct {
 }
 
 func (c *nodeCmd) Run() error {
+	// TODO: handle cp using tar'd stdin
 	args := []string{
 		"exec",
 		// run with privileges so we can remount etc..


### PR DESCRIPTION
By using docker/podman cp/kill directly we can avoid needing cp/mkdir/kill in the final container image. Files are tar'd and passed via stdin to `docker cp` directly. `docker kill` is called to trigger config reload instead of call kill inside the container.

Admittedly this is a pretty small optimization, but wanted to see if there was any interest in solution similar to this so the final haproxy image really only has haproxy (plus distroless cc) in it.

I haven't test podman yet, but according to the docs it should function the same way.  We could also avoid using `cat` [here](https://github.com/jaxesn/kind/pull/1/files#diff-f27efd6b0e4f4b09a6bcf127aa4681d2c9bc33e9ae689344c31efd7e55fc441cR77), if that was desirable, by use `docker cp` with stdout instead, but that is not necessary for the haproxy use case.

TODO:

- [ ] Support via podman as well as docker
- [ ] Change nodeimage helper to use a tar file instead of calling cp